### PR TITLE
ci: declare explicit GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,9 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   SCCACHE_CACHE_SIZE: "50GB"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The product-security baseline rollout will set the repository default `GITHUB_TOKEN` permissions to **read-only** (with PR-approval by the token disabled). Workflows that rely on the current implicit write default would start failing at their next write operation. This PR makes each workflow's required permissions explicit so the downgrade is a no-op for this repo.

| Workflow | Declared permissions |
|---|---|
| `.github/workflows/check.yml` | `contents: read` |
| `.github/workflows/test.yml` | `contents: read` |

Scopes were inferred from the actions and commands each workflow uses; read-only workflows get `contents: read`. Draft on purpose — please review before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)